### PR TITLE
Fix build errors with Spring WS

### DIFF
--- a/src/main/java/com/example/helloservice/config/WebServiceConfig.java
+++ b/src/main/java/com/example/helloservice/config/WebServiceConfig.java
@@ -7,10 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.ws.config.annotation.EnableWs;
 import org.springframework.ws.transport.http.MessageDispatcherServlet;
-import org.springframework.ws.soap.SoapVersion;
-import org.springframework.ws.soap.saaj.SaajSoapMessageFactory;
 import org.springframework.ws.wsdl.wsdl11.DefaultWsdl11Definition;
-import org.springframework.ws.wsdl.wsdl11.Soap12Wsdl11Definition;
 import org.springframework.xml.xsd.SimpleXsdSchema;
 import org.springframework.xml.xsd.XsdSchema;
 
@@ -31,15 +28,7 @@ public class WebServiceConfig {
         MessageDispatcherServlet servlet = new MessageDispatcherServlet();
         servlet.setApplicationContext(ctx);
         servlet.setTransformWsdlLocations(true);
-        servlet.setMessageFactory(soap12MessageFactory());
         return new ServletRegistrationBean<>(servlet, "/services/HelloService12/*");
-    }
-
-    @Bean
-    public SaajSoapMessageFactory soap12MessageFactory() {
-        SaajSoapMessageFactory f = new SaajSoapMessageFactory();
-        f.setSoapVersion(SoapVersion.SOAP_12);
-        return f;
     }
 
     @Bean(name = "HelloService")
@@ -53,8 +42,8 @@ public class WebServiceConfig {
     }
 
     @Bean(name = "HelloService12")
-    public Soap12Wsdl11Definition helloWsdl12(XsdSchema schema) {
-        Soap12Wsdl11Definition def = new Soap12Wsdl11Definition();
+    public DefaultWsdl11Definition helloWsdl12(XsdSchema schema) {
+        DefaultWsdl11Definition def = new DefaultWsdl11Definition();
         def.setPortTypeName("HelloPort");
         def.setLocationUri("/services/HelloService12");
         def.setTargetNamespace("http://example.com/hello");


### PR DESCRIPTION
## Summary
- remove non-existent SOAP 1.2 APIs from WebServiceConfig
- use DefaultWsdl11Definition for both endpoints

## Testing
- `mvn clean install` *(fails: `mvn: command not found`)*